### PR TITLE
Adopt changes to protocol outlined in Treetop Go library v0.3.0

### DIFF
--- a/API.markdown
+++ b/API.markdown
@@ -216,9 +216,5 @@ treetop.unmount( [HTMLElement])
 | oldElement        | `HTMLElement` | Element attached to the DOM remove and unmount |
 
 
-
-## treetop.PARTIAL_CONTENT_TYPE
-The Treetop partial content type value supported by this version of the treetop client.
-
-## treetop.FRAGMENT_CONTENT_TYPE
-The Treetop fragment content type value supported by this version of the treetop client.
+## treetop.TEMPLATE_CONTENT_TYPE
+The Treetop content type value supported by the server-side handlers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.9.0] - WIP
+## [0.9.0] - 2020-03-10
 
 Adopt changes to Treetop protocol in v0.3.0 of the Go library.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [0.9.0] - WIP
+
+Adopt changes to Treetop protocol in v0.3.0 of the Go library.
+
+### Changed
+
+- Treetop content type changed to `application/x.treetop-html-template+xml`
+- Response URL is renamed to `X-Page-URL` and is now optional
+- Response body can now come wrapped in a `<template>...</template>` tag
+
+### Redirects
+- Redirects now use `Location` header
+- Status will continue to be 200
+- There must be a header named `X-Treetop-Redirect` with a value of `SeeOther`
+
 ## [0.8.1] - 2019-10-17
 
 ### Changed

--- a/README.markdown
+++ b/README.markdown
@@ -26,18 +26,19 @@ treetop.request(
 ### Initialization
 
 To make use of custom integration hooks and the built-in components, the client library
-must be initialized before any partial requests are made. Late arriving configuration
-will be rejected.
+must be initialized before any partial requests are made.
 
 <!-- TODO: add troubleshooting docs -->
 
 Initialization can be triggered actively using `treetop.init({...})` or passively by
-declaring a global variable `window.TREETOP_CONFIG` __before__ the client script loads.
-The config object is the same in both cases.
+declaring a global variable `window.TREETOP_CONFIG` _before_ the client script loads.
+The config object is identical in both cases.
 
-#### Config Example
+#### Config Example (passive)
+
 ```
-window.init({
+<script>
+window.TREETOP_CONFIG = {
   treetopAttr: true,
   mountAttrs: {
     "my-attr": (el) => { /*...*/ },
@@ -50,30 +51,9 @@ window.init({
   },
   onNetworkError: (xhr) => { /*...*/ },
   onUnsupported: (xhr) => { /*...*/ }
-});
-```
-
-## Treetop Browser Events
-
-When the client library is used to make an XHR request, events will be dispatched to indicate overall loading status.
-Note that, by design, the context of specific requests cannot be accessed this way.
-
-### Treetop Event Types:
-
-#### `"treetopstart"`
-This event is dispatched when an XHR request is initiated. It will only execute once for concurrent requests.
-#### `"treetopcomplete"`
-This event is dispatched when all active XHR requests are completed.
-
-#### Example
-
-```
-document.addEventListener("treetopstart", function () {
-    document.body.classList.add("loading");
-});
-document.addEventListener("treetopcomplete", function () {
-    document.body.classList.remove("loading");
-});
+};
+</script>
+<script src="treetop.js" async></script>
 ```
 
 ## Mounting Component
@@ -183,6 +163,29 @@ This custom merge implementation will be triggered if both new and old elements 
 
 <!-- new -->
 <ul id="list" treetop-merge="append-children"><li...
+```
+
+## Browser Events
+
+When the client library is used to make an XHR request, events will be dispatched to indicate overall loading status.
+Note that, by design, the context of specific requests cannot be accessed this way.
+
+### Event Types:
+
+#### `"treetopstart"`
+This event is dispatched when an XHR request is initiated. It will only execute once for concurrent requests.
+#### `"treetopcomplete"`
+This event is dispatched when all active XHR requests are completed.
+
+#### Example
+
+```
+document.addEventListener("treetopstart", function () {
+    document.body.classList.add("loading");
+});
+document.addEventListener("treetopcomplete", function () {
+    document.body.classList.remove("loading");
+});
 ```
 
 ## Browser Support & Ployfills

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "treetop-client",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treetop-client",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Browser client library for Treetop enabled web application",
   "main": "treetop.js",
   "scripts": {

--- a/treetop.js
+++ b/treetop.js
@@ -518,6 +518,9 @@ window.treetop = (function ($) {
         // this will require a polyfil for browsers that do not support HTMLTemplateElement
         tmpl = document.createElement("template");
         tmpl.innerHTML = xhr.responseText;
+        if (tmpl.content.children.length === 1 && tmpl.content.firstChild.tagName === "TEMPLATE") {
+            tmpl = tmpl.content.firstChild
+        }
         matches = []
         for (i = 0, len = tmpl.content.children.length; i < len; i++) {
             neu = this.wrapElement(tmpl.content.children[i]);

--- a/treetop.js
+++ b/treetop.js
@@ -367,7 +367,7 @@ window.treetop = (function ($) {
                 $.xhrProcess(xhr, requestID, pageURL !== null);
                 return
             }
-            
+
             if(typeof $.onUnsupported === "function") {
                 // Fall through; this is not a response that treetop supports.
                 // Allow developer to handle.

--- a/treetop.spec.js
+++ b/treetop.spec.js
@@ -156,6 +156,28 @@ describe('Treetop', () => {
       expect(document.getElementById("test").textContent).to.equal("after!");
     });
 
+    it('should handle utf-8 encoded string', () => {
+      treetop.request("GET", "/test");
+      requests[0].respond(
+        200,
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
+        '<template><em id="test">🕺!</em></template>'
+      );
+      window.flushTimers()
+      expect(document.getElementById("test").textContent).to.equal("🕺!");
+    });
+
+    it('should handle a string with html entities encoding for unicode characters', () => {
+      treetop.request("GET", "/test");
+      requests[0].respond(
+        200,
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
+        '<template><em id="test">&#x1F57A!</em></template>'
+      );
+      window.flushTimers()
+      expect(document.getElementById("test").textContent).to.equal("🕺!");
+    });
+
     it('should work without template tags', () => {
       treetop.request("GET", "/test");
       requests[0].respond(

--- a/treetop.spec.js
+++ b/treetop.spec.js
@@ -55,7 +55,7 @@ describe('Treetop', () => {
     it('should have added the treetop header', () => {
       window.treetop.request("GET", "/test");
       var req = requests[0];
-      expect(req.requestHeaders["accept"]).to.contain(treetop.PARTIAL_CONTENT_TYPE)
+      expect(req.requestHeaders["accept"]).to.contain(treetop.TEMPLATE_CONTENT_TYPE)
     });
 
     it('should have no body', () => {
@@ -76,7 +76,7 @@ describe('Treetop', () => {
       expect(req).to.exist;
       expect(req.url).to.contain("/test");
       expect(req.method).to.equal("POST");
-      expect(req.requestHeaders["accept"]).to.contain(treetop.PARTIAL_CONTENT_TYPE);
+      expect(req.requestHeaders["accept"]).to.contain(treetop.TEMPLATE_CONTENT_TYPE);
       expect(req.url).to.equal("/test");
     });
 
@@ -149,7 +149,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<em id="test">after!</em>'
       );
       window.flushTimers()
@@ -160,7 +160,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<em id="test_other">after!</em>'
       );
       window.flushTimers()
@@ -182,7 +182,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         'TESTING'
       );
       window.flushTimers()
@@ -193,7 +193,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<form id="test"><p>OK!</p><input name="tagName"/></form>'
       );
       window.flushTimers()
@@ -204,14 +204,14 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<form id="test"><p>FIRST!</p><input name="parentElement"/></form>'
       );
       window.flushTimers()
       treetop.request("GET", "/test");
       requests[1].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<form id="test"><p>SECOND!</p><input name="othername"/></form>'
       );
       expect(document.getElementById("test").textContent).to.equal("SECOND!");
@@ -235,13 +235,13 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[1].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE, 'X-Page-URL': "/test" },
         '<em id="test">sooner!</em>'
      );
       window.flushTimers()
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE, 'X-Page-URL': "/test" },
         '<em id="test">later!</em>'
       );
       window.flushTimers()
@@ -257,13 +257,13 @@ describe('Treetop', () => {
       treetop.request("GET", "/test2");
       requests[1].respond(
         200,
-        { 'content-type': treetop.FRAGMENT_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<em id="test">sooner!</em>'
       );
       window.flushTimers()
       requests[0].respond(
         200,
-        { 'content-type': treetop.FRAGMENT_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<em id="test2">later!</em>'
       );
       window.flushTimers()
@@ -281,13 +281,13 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[1].respond(
         200,
-        { 'content-type': treetop.FRAGMENT_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<p id="test"><span id="test-sub">container!</span></p>'
       );
       window.flushTimers()
       requests[0].respond(
         200,
-        { 'content-type': treetop.FRAGMENT_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<em id="test-sub">child!</em>'
       );
       window.flushTimers()
@@ -314,7 +314,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<ul id="test" treetop-merge="test"><li>4</li><li>5</li><li>6</li></ul>'
       );
       window.flushTimers()
@@ -325,7 +325,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<ul id="test" treetop-merge="something-else"><li>4</li><li>5</li><li>6</li></ul>'
       );
       window.flushTimers()
@@ -343,7 +343,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<title>New Title!</title>'
       );
       window.flushTimers()
@@ -354,7 +354,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<body><p id="test">New Body!</p></body>'
       );
       window.flushTimers()
@@ -367,7 +367,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<tr id="test"><td>New Cell!</td></tr>'
       );
       window.flushTimers()
@@ -390,7 +390,7 @@ describe('Treetop', () => {
         treetop.request("GET", "/test");
         requests[0].respond(
           200,
-          { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+          { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
           '<em id="test">after!</em>'
         );
         window.flushTimers()
@@ -426,7 +426,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<div id="test"><p id="test-child" test>New Cell!</p></div>'
       );
       window.flushTimers()
@@ -439,7 +439,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<div id="test"><p id="test-child" test>New Cell!</p></div>'
       );
       window.flushTimers()
@@ -453,7 +453,7 @@ describe('Treetop', () => {
         treetop.request("GET", "/test");
         requests[0].respond(
           200,
-          { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+          { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
           '<div id="test"><p id="test-child" test>New Cell!</p></div>'
         );
         window.flushTimers() // ensure any errors are raised at this stage
@@ -461,7 +461,7 @@ describe('Treetop', () => {
         treetop.request("GET", "/test");
         requests[1].respond(
           200,
-          { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+          { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
           '<div id="test">after!</div><div id="test2">after2!</div>'
         );
         window.flushTimers()
@@ -477,7 +477,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<div id="test"><p id="test-child" test test2>New Cell!</p></div>'
       );
       window.flushTimers()
@@ -493,7 +493,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[0].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<div id="test"><p id="test-child" test test2>New Data</p></div>'
       );
       window.flushTimers()
@@ -501,7 +501,7 @@ describe('Treetop', () => {
       treetop.request("GET", "/test");
       requests[1].respond(
         200,
-        { 'content-type': treetop.PARTIAL_CONTENT_TYPE },
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
         '<div id="test">replaced</div>'
       );
       window.flushTimers()

--- a/treetop.spec.js
+++ b/treetop.spec.js
@@ -150,7 +150,18 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<em id="test">after!</em>'
+        '<template><em id="test">after!</em></template>'
+      );
+      window.flushTimers()
+      expect(document.getElementById("test").textContent).to.equal("after!");
+    });
+
+    it('should work without template tags', () => {
+      treetop.request("GET", "/test");
+      requests[0].respond(
+        200,
+        { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
+        '<template><em id="test">after!</em></template>'
       );
       window.flushTimers()
       expect(document.getElementById("test").textContent).to.equal("after!");
@@ -161,7 +172,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<em id="test_other">after!</em>'
+        '<template><em id="test_other">after!</em></template>'
       );
       window.flushTimers()
       expect(document.getElementById("test").textContent).to.equal("before!");
@@ -194,7 +205,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<form id="test"><p>OK!</p><input name="tagName"/></form>'
+        '<template><form id="test"><p>OK!</p><input name="tagName"/></form></template>'
       );
       window.flushTimers()
       expect(document.getElementById("test").textContent).to.equal("OK!");
@@ -205,14 +216,14 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<form id="test"><p>FIRST!</p><input name="parentElement"/></form>'
+        '<template><form id="test"><p>FIRST!</p><input name="parentElement"/></form></template>'
       );
       window.flushTimers()
       treetop.request("GET", "/test");
       requests[1].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<form id="test"><p>SECOND!</p><input name="othername"/></form>'
+        '<template><form id="test"><p>SECOND!</p><input name="othername"/></form></template>'
       );
       expect(document.getElementById("test").textContent).to.equal("SECOND!");
     });
@@ -236,13 +247,13 @@ describe('Treetop', () => {
       requests[1].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE, 'X-Page-URL': "/test" },
-        '<em id="test">sooner!</em>'
+        '<template><em id="test">sooner!</em></template>'
      );
       window.flushTimers()
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE, 'X-Page-URL': "/test" },
-        '<em id="test">later!</em>'
+        '<template><em id="test">later!</em></template>'
       );
       window.flushTimers()
       expect(document.getElementById("test").textContent).to.equal("sooner!");
@@ -258,13 +269,13 @@ describe('Treetop', () => {
       requests[1].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<em id="test">sooner!</em>'
+        '<template><em id="test">sooner!</em></template>'
       );
       window.flushTimers()
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<em id="test2">later!</em>'
+        '<template><em id="test2">later!</em></template>'
       );
       window.flushTimers()
       expect(document.getElementById("test").textContent).to.equal("sooner!");
@@ -282,13 +293,13 @@ describe('Treetop', () => {
       requests[1].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<p id="test"><span id="test-sub">container!</span></p>'
+        '<template><p id="test"><span id="test-sub">container!</span></p></template>'
       );
       window.flushTimers()
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<em id="test-sub">child!</em>'
+        '<template><em id="test-sub">child!</em></template>'
       );
       window.flushTimers()
       expect(document.getElementById("test").textContent).to.equal("container!");
@@ -315,7 +326,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<ul id="test" treetop-merge="test"><li>4</li><li>5</li><li>6</li></ul>'
+        '<template><ul id="test" treetop-merge="test"><li>4</li><li>5</li><li>6</li></ul></template>'
       );
       window.flushTimers()
       expect(document.getElementById("test").textContent).to.equal("123456");
@@ -326,7 +337,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<ul id="test" treetop-merge="something-else"><li>4</li><li>5</li><li>6</li></ul>'
+        '<template><ul id="test" treetop-merge="something-else"><li>4</li><li>5</li><li>6</li></ul></template>'
       );
       window.flushTimers()
       expect(document.getElementById("test").textContent).to.equal("456");
@@ -344,7 +355,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<title>New Title!</title>'
+        '<template><title>New Title!</title></template>'
       );
       window.flushTimers()
       expect(document.title).to.equal("New Title!");
@@ -355,7 +366,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<body><p id="test">New Body!</p></body>'
+        '<template><body><p id="test">New Body!</p></body></template>'
       );
       window.flushTimers()
       expect(document.getElementById("test")).to.be.null;
@@ -368,7 +379,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<tr id="test"><td>New Cell!</td></tr>'
+        '<template><tr id="test"><td>New Cell!</td></tr></template>'
       );
       window.flushTimers()
       expect(document.getElementById("test").textContent).to.equal("New Cell!");
@@ -391,7 +402,7 @@ describe('Treetop', () => {
         requests[0].respond(
           200,
           { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-          '<em id="test">after!</em>'
+          '<template><em id="test">after!</em></template>'
         );
         window.flushTimers()
         this.nue = document.getElementById('test');
@@ -427,7 +438,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<div id="test"><p id="test-child" test>New Cell!</p></div>'
+        '<template><div id="test"><p id="test-child" test>New Cell!</p></div></template>'
       );
       window.flushTimers()
       var el = document.getElementById("test-child");
@@ -440,7 +451,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<div id="test"><p id="test-child" test>New Cell!</p></div>'
+        '<template><div id="test"><p id="test-child" test>New Cell!</p></div></template>'
       );
       window.flushTimers()
       var el = document.getElementById("test-child");
@@ -478,7 +489,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<div id="test"><p id="test-child" test test2>New Cell!</p></div>'
+        '<template><div id="test"><p id="test-child" test test2>New Cell!</p></div></template>'
       );
       window.flushTimers()
       el = document.getElementById("test-child");
@@ -494,7 +505,7 @@ describe('Treetop', () => {
       requests[0].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<div id="test"><p id="test-child" test test2>New Data</p></div>'
+        '<template><div id="test"><p id="test-child" test test2>New Data</p></div></template>'
       );
       window.flushTimers()
       el = document.getElementById("test-child");
@@ -502,7 +513,7 @@ describe('Treetop', () => {
       requests[1].respond(
         200,
         { 'content-type': treetop.TEMPLATE_CONTENT_TYPE },
-        '<div id="test">replaced</div>'
+        '<template><div id="test">replaced</div></template>'
       );
       window.flushTimers()
       expect(calledWithStrict(unmount, el)).to.be.true;


### PR DESCRIPTION
see https://github.com/rur/treetop/pull/10

Adopt changes to Treetop protocol in v0.3.0 of the Go library.

### Changed

- Treetop content type changed to `application/x.treetop-html-template+xml`
- Response URL is renamed to `X-Page-URL` and is now optional
- Response body can now come wrapped in a `<template>...</template>` tag

### Redirects
- Redirects now use `Location` header
- Status will continue to be 200
- There must be a header named `X-Treetop-Redirect` with a value of `SeeOther`